### PR TITLE
Add custode schedule import button

### DIFF
--- a/index.html
+++ b/index.html
@@ -701,7 +701,7 @@
                 navigationHistory.push(e);
             }
 
-            if (['supervisore', 'adm'].includes(userType) && ['userManagement', 'gestioneGruppi', 'importazione'].includes(e)) {
+            if (['supervisore', 'adm'].includes(userType) && ['userManagement', 'gestioneGruppi', 'importazione', 'orariCustode'].includes(e)) {
                  currentPage = e;
                  renderCurrentPage();
                  return;
@@ -1482,11 +1482,60 @@
                         </div>
                     </div>
                 </div>
+
+                <!-- SEZIONE 3: IMPORTAZIONE ORARI CUSTODE -->
+                <div class="card">
+                    <h3 class="card-title">Importa Orari Custode</h3>
+                    <p class="form-label" style="margin-bottom: 1.5rem; color: var(--secondary-text);">
+                        Carica il file Excel contenente gli orari del custode. Il sistema utilizzerà esclusivamente il primo foglio del file caricato. Questi dati verranno visualizzati nella sezione "Custode".
+                    </p>
+                    <div class="form-group">
+                        <label class="form-label">Carica File Orari Custode (.xlsx, .xls)</label>
+                        <input type="file" id="excel-file-input-orari-custode-import" class="form-input" accept=".xlsx, .xls">
+                    </div>
+                    <div id="message-import-orari-custode-import" class="message-box"></div>
+                    <div id="save-button-container-orari-custode-import" class="hidden mt-4">
+                        <button id="save-imported-data-btn-orari-custode-import" class="btn btn-primary w-full">Salva Orari Custode</button>
+                    </div>
+                    <div class="mt-4">
+                        <h4 class="section-title" style="font-size: 1rem; margin-bottom: 0.5rem;">Anteprima / Dati Attuali</h4>
+                        <div id="excel-table-container-orari-custode-import" class="data-table-container">
+                            <p style="color:var(--secondary-text);">Nessun orario custode ancora importato.</p>
+                        </div>
+                    </div>
+                </div>
+            </main>
+            ${renderBottomNavigation()}
+        `;
+
+        const renderOrariCustode = () => `
+            ${renderHeader('Importa Orari Custode')}
+            <main>
+                <div class="card" style="margin-bottom: 2rem;">
+                    <h3 class="card-title">Importa Orari Custode</h3>
+                    <p class="form-label" style="margin-bottom: 1.5rem; color: var(--secondary-text);">
+                        Carica il file Excel contenente gli orari del custode. Il sistema utilizzerà esclusivamente il primo foglio del file caricato.
+                    </p>
+                    <div class="form-group">
+                        <label class="form-label">Carica File Orari Custode (.xlsx, .xls)</label>
+                        <input type="file" id="excel-file-input-orari-custode" class="form-input" accept=".xlsx, .xls">
+                    </div>
+                    <div id="message-import-orari-custode" class="message-box"></div>
+                    <div id="save-button-container-orari-custode" class="hidden mt-4">
+                        <button id="save-imported-data-btn-orari-custode" class="btn btn-primary w-full">Salva Orari Custode</button>
+                    </div>
+                    <div class="mt-4">
+                        <h4 class="section-title" style="font-size: 1rem; margin-bottom: 0.5rem;">Anteprima / Dati Attuali</h4>
+                        <div id="excel-table-container-orari-custode" class="data-table-container">
+                            <p style="color:var(--secondary-text);">Nessun file selezionato o caricato.</p>
+                        </div>
+                    </div>
+                </div>
             </main>
             ${renderBottomNavigation()}
         `;
         
-                const renderGestioneGruppiMenu = () => `
+        const renderGestioneGruppiMenu = () => `
             ${renderHeader('Funzioni Supervisor')}
             <main>
                 <div class="dashboard-grid" style="grid-template-columns: 1fr;">
@@ -1518,6 +1567,12 @@
                         <div class="dashboard-card" style="aspect-ratio: auto; padding: 1.5rem; flex-direction: row; justify-content: flex-start; gap: 1.5rem;">
                             <svg fill="currentColor" viewBox="0 0 24 24" style="width: 32px; height: 32px; flex-shrink: 0;"><path d="M3,5H9V11H3V5M5,7V9H7V7H5M11,7H21V9H11V7M11,15H21V17H11V15M5,15H7V17H5V15M3,13H9V19H3V13Z" /></svg>
                             <p style="text-align: left; font-size: 1.1rem;">Gestione Sondaggi</p>
+                        </div>
+                    </div>
+                    <div onclick="navigateTo('orariCustode')" class="dashboard-item">
+                        <div class="dashboard-card" style="aspect-ratio: auto; padding: 1.5rem; flex-direction: row; justify-content: flex-start; gap: 1.5rem;">
+                            <svg fill="currentColor" viewBox="0 0 24 24" style="width: 32px; height: 32px; flex-shrink: 0;"><path d="M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M16.2,16.2L11,13V7H12.5V12.2L17,14.9L16.2,16.2Z"/></svg>
+                            <p style="text-align: left; font-size: 1.1rem;">Orari Custode</p>
                         </div>
                     </div>
                 </div>
@@ -1778,6 +1833,10 @@
                     if (userType === 'supervisore') content = renderImportazione();
                     else navigateTo('dashboard');
                     break;
+                case 'orariCustode':
+                    if (userType === 'supervisore') content = renderOrariCustode();
+                    else navigateTo('dashboard');
+                    break;
                 case 'reportPage':
                     content = renderReportPage();
                     break;
@@ -1847,6 +1906,7 @@
                 case 'gestioneGruppi_lista': if (['supervisore', 'adm'].includes(userType)) { loadPartialCondos(); setupUserManagementHandlers(); } break;
                 case 'gestioneGruppi_regole': if (['supervisore', 'adm'].includes(userType)) { loadGroupRules(); setupGestioneGruppiHandlers(); } break;
                 case 'importazione': if (userType === 'supervisore') { setupImportazioneHandlers(); } break;
+                case 'orariCustode': if (userType === 'supervisore') { setupOrariCustodeHandlers(); } break;
                 case 'impostazioniSondaggi': if (['supervisore', 'adm'].includes(userType)) { setupImpostazioniSondaggiHandlers(); } break;
             }
 
@@ -2549,6 +2609,221 @@
 
             await loadPrerequisites();
             await Promise.all([loadLatestMillesimiData(), loadLatestPhoneData()]);
+
+            // Setup handlers for custode schedule import in the import page
+            const fileInputOrariCustodeImport = document.getElementById('excel-file-input-orari-custode-import');
+            const tableContainerOrariCustodeImport = document.getElementById('excel-table-container-orari-custode-import');
+            const messageBoxOrariCustodeImport = document.getElementById('message-import-orari-custode-import');
+            const saveBtnContainerOrariCustodeImport = document.getElementById('save-button-container-orari-custode-import');
+            const saveBtnOrariCustodeImport = document.getElementById('save-imported-data-btn-orari-custode-import');
+            let orariCustodeImportFileName = '';
+            let orariCustodeImportDataToSave = null;
+
+            const generateOrariCustodeTableHTML = (data) => {
+                if (!data || data.length === 0) return '<p style="color:var(--secondary-text);">Nessun dato da visualizzare.</p>';
+                let tableHTML = `<table class="data-table" id="orari-custode-import-preview-table">`;
+                const headers = Object.keys(data[0]);
+                tableHTML += '<thead><tr>' + headers.map(h => `<th>${h}</th>`).join('') + '</tr></thead><tbody>';
+                data.forEach(row => {
+                    tableHTML += '<tr>';
+                    headers.forEach(header => {
+                        const cellValue = row[header] !== undefined ? row[header] : '';
+                        tableHTML += `<td>${cellValue}</td>`;
+                    });
+                    tableHTML += '</tr>';
+                });
+                return tableHTML + '</tbody></table>';
+            };
+
+            const loadLatestOrariCustodeImportData = async () => {
+                const q = query(collection(db, "importedCustodeSchedule"), orderBy("uploadedAt", "desc"), limit(1));
+                const snapshot = await getDocs(q);
+                if (!snapshot.empty) {
+                    const docData = snapshot.docs[0].data();
+                    const data = docData.tableData;
+                    tableContainerOrariCustodeImport.innerHTML = generateOrariCustodeTableHTML(data);
+                    saveBtnContainerOrariCustodeImport.classList.remove('hidden');
+                    orariCustodeImportFileName = docData.fileName || 'orari_custode_esistenti.xlsx';
+                } else {
+                    tableContainerOrariCustodeImport.innerHTML = '<p style="color:var(--secondary-text);">Nessun orario custode ancora importato.</p>';
+                    saveBtnContainerOrariCustodeImport.classList.add('hidden');
+                }
+            };
+
+            fileInputOrariCustodeImport.addEventListener('change', (event) => {
+                const file = event.target.files[0];
+                orariCustodeImportFileName = '';
+                orariCustodeImportDataToSave = null;
+                saveBtnContainerOrariCustodeImport.classList.add('hidden');
+                messageBoxOrariCustodeImport.style.display = 'none';
+                
+                if (!file) { 
+                    loadLatestOrariCustodeImportData(); 
+                    return; 
+                }
+                
+                orariCustodeImportFileName = file.name;
+                tableContainerOrariCustodeImport.innerHTML = '<p>Caricamento anteprima...</p>';
+                
+                const reader = new FileReader();
+                reader.onload = (e) => {
+                    try {
+                        const data = new Uint8Array(e.target.result);
+                        const workbook = XLSX.read(data, { type: 'array' });
+                        // Utilizza solo il primo foglio del file Excel
+                        const jsonData = XLSX.utils.sheet_to_json(workbook.Sheets[workbook.SheetNames[0]]);
+                        if (jsonData.length === 0) throw new Error("Il file è vuoto.");
+                        orariCustodeImportDataToSave = jsonData;
+                        tableContainerOrariCustodeImport.innerHTML = generateOrariCustodeTableHTML(jsonData);
+                        saveBtnContainerOrariCustodeImport.classList.remove('hidden');
+                    } catch (err) {
+                        messageBoxOrariCustodeImport.className = 'message-box error';
+                        messageBoxOrariCustodeImport.textContent = `Errore: ${err.message}`;
+                        messageBoxOrariCustodeImport.style.display = 'block';
+                    }
+                };
+                reader.readAsArrayBuffer(file);
+            });
+
+            saveBtnOrariCustodeImport.addEventListener('click', async () => {
+                if (!orariCustodeImportDataToSave) return;
+                saveBtnOrariCustodeImport.disabled = true;
+                saveBtnOrariCustodeImport.textContent = 'Salvataggio...';
+                
+                try {
+                    await addDoc(collection(db, "importedCustodeSchedule"), {
+                        fileName: orariCustodeImportFileName,
+                        tableData: orariCustodeImportDataToSave,
+                        uploadedBy: currentUser.uid,
+                        uploadedAt: serverTimestamp()
+                    });
+                    await logActivity("custode_schedule_imported", currentUser.uid, `${userProfile.nome} ${userProfile.cognome}`, { fileName: orariCustodeImportFileName });
+                    fileInputOrariCustodeImport.value = '';
+                    saveBtnContainerOrariCustodeImport.classList.add('hidden');
+                    messageBoxOrariCustodeImport.className = 'message-box success';
+                    messageBoxOrariCustodeImport.textContent = 'Orari custode salvati con successo!';
+                    messageBoxOrariCustodeImport.style.display = 'block';
+                    setTimeout(() => { messageBoxOrariCustodeImport.style.display = 'none'; }, 3000);
+                    await loadLatestOrariCustodeImportData();
+                } catch (error) {
+                    messageBoxOrariCustodeImport.className = 'message-box error';
+                    messageBoxOrariCustodeImport.textContent = `Errore durante il salvataggio: ${error.message}`;
+                    messageBoxOrariCustodeImport.style.display = 'block';
+                } finally {
+                    saveBtnOrariCustodeImport.disabled = false;
+                    saveBtnOrariCustodeImport.textContent = 'Salva Orari Custode';
+                }
+            });
+
+            await loadLatestOrariCustodeImportData();
+        };
+
+        const setupOrariCustodeHandlers = async () => {
+            const fileInputOrariCustode = document.getElementById('excel-file-input-orari-custode');
+            const tableContainerOrariCustode = document.getElementById('excel-table-container-orari-custode');
+            const messageBoxOrariCustode = document.getElementById('message-import-orari-custode');
+            const saveBtnContainerOrariCustode = document.getElementById('save-button-container-orari-custode');
+            const saveBtnOrariCustode = document.getElementById('save-imported-data-btn-orari-custode');
+            let orariCustodeFileName = '';
+            let orariCustodeDataToSave = null;
+
+            const generateTableHTML = (data) => {
+                if (!data || data.length === 0) return '<p style="color:var(--secondary-text);">Nessun dato da visualizzare.</p>';
+                let tableHTML = `<table class="data-table" id="orari-custode-preview-table">`;
+                const headers = Object.keys(data[0]);
+                tableHTML += '<thead><tr>' + headers.map(h => `<th>${h}</th>`).join('') + '</tr></thead><tbody>';
+                data.forEach(row => {
+                    tableHTML += '<tr>';
+                    headers.forEach(header => {
+                        const cellValue = row[header] !== undefined ? row[header] : '';
+                        tableHTML += `<td>${cellValue}</td>`;
+                    });
+                    tableHTML += '</tr>';
+                });
+                return tableHTML + '</tbody></table>';
+            };
+
+            const loadLatestOrariCustodeData = async () => {
+                const q = query(collection(db, "importedCustodeSchedule"), orderBy("uploadedAt", "desc"), limit(1));
+                const snapshot = await getDocs(q);
+                if (!snapshot.empty) {
+                    const docData = snapshot.docs[0].data();
+                    const data = docData.tableData;
+                    tableContainerOrariCustode.innerHTML = generateTableHTML(data);
+                    saveBtnContainerOrariCustode.classList.remove('hidden');
+                    orariCustodeFileName = docData.fileName || 'orari_custode_esistenti.xlsx';
+                } else {
+                    tableContainerOrariCustode.innerHTML = '<p style="color:var(--secondary-text);">Nessun orario custode ancora importato.</p>';
+                    saveBtnContainerOrariCustode.classList.add('hidden');
+                }
+            };
+
+            fileInputOrariCustode.addEventListener('change', (event) => {
+                const file = event.target.files[0];
+                orariCustodeFileName = '';
+                orariCustodeDataToSave = null;
+                saveBtnContainerOrariCustode.classList.add('hidden');
+                messageBoxOrariCustode.style.display = 'none';
+                
+                if (!file) { 
+                    loadLatestOrariCustodeData(); 
+                    return; 
+                }
+                
+                orariCustodeFileName = file.name;
+                tableContainerOrariCustode.innerHTML = '<p>Caricamento anteprima...</p>';
+                
+                const reader = new FileReader();
+                reader.onload = (e) => {
+                    try {
+                        const data = new Uint8Array(e.target.result);
+                        const workbook = XLSX.read(data, { type: 'array' });
+                        // Utilizza solo il primo foglio del file Excel
+                        const jsonData = XLSX.utils.sheet_to_json(workbook.Sheets[workbook.SheetNames[0]]);
+                        if (jsonData.length === 0) throw new Error("Il file è vuoto.");
+                        orariCustodeDataToSave = jsonData;
+                        tableContainerOrariCustode.innerHTML = generateTableHTML(jsonData);
+                        saveBtnContainerOrariCustode.classList.remove('hidden');
+                    } catch (err) {
+                        messageBoxOrariCustode.className = 'message-box error';
+                        messageBoxOrariCustode.textContent = `Errore: ${err.message}`;
+                        messageBoxOrariCustode.style.display = 'block';
+                    }
+                };
+                reader.readAsArrayBuffer(file);
+            });
+
+            saveBtnOrariCustode.addEventListener('click', async () => {
+                if (!orariCustodeDataToSave) return;
+                saveBtnOrariCustode.disabled = true;
+                saveBtnOrariCustode.textContent = 'Salvataggio...';
+                
+                try {
+                    await addDoc(collection(db, "importedCustodeSchedule"), {
+                        fileName: orariCustodeFileName,
+                        tableData: orariCustodeDataToSave,
+                        uploadedBy: currentUser.uid,
+                        uploadedAt: serverTimestamp()
+                    });
+                    await logActivity("custode_schedule_imported", currentUser.uid, `${userProfile.nome} ${userProfile.cognome}`, { fileName: orariCustodeFileName });
+                    fileInputOrariCustode.value = '';
+                    saveBtnContainerOrariCustode.classList.add('hidden');
+                    messageBoxOrariCustode.className = 'message-box success';
+                    messageBoxOrariCustode.textContent = 'Orari custode salvati con successo!';
+                    messageBoxOrariCustode.style.display = 'block';
+                    setTimeout(() => { messageBoxOrariCustode.style.display = 'none'; }, 3000);
+                    await loadLatestOrariCustodeData();
+                } catch (error) {
+                    messageBoxOrariCustode.className = 'message-box error';
+                    messageBoxOrariCustode.textContent = `Errore durante il salvataggio: ${error.message}`;
+                    messageBoxOrariCustode.style.display = 'block';
+                } finally {
+                    saveBtnOrariCustode.disabled = false;
+                    saveBtnOrariCustode.textContent = 'Salva Orari Custode';
+                }
+            });
+
+            await loadLatestOrariCustodeData();
         };
 
         const setupUserManagementHandlers = () => {
@@ -3403,12 +3678,23 @@
         const renderNumeriUtiliCustode = () => `
             ${renderHeader('Contatti Custode')}
             <main>
-                <div class="card">
+                <div class="card" style="margin-bottom: 2rem;">
+                    <h3 class="card-title">Contatti del Custode</h3>
                     <p class="form-label" style="color: var(--secondary-text); margin-bottom: 2rem;">
                         Contatti del custode del condominio.
                     </p>
                     <div id="custode-container" class="data-table-container">
                         <p style="color:var(--secondary-text);">Caricamento contatti custode...</p>
+                    </div>
+                </div>
+
+                <div class="card">
+                    <h3 class="card-title">Orari del Custode</h3>
+                    <p class="form-label" style="color: var(--secondary-text); margin-bottom: 2rem;">
+                        Orari di servizio del custode del condominio.
+                    </p>
+                    <div id="custode-schedule-container" class="data-table-container">
+                        <p style="color:var(--secondary-text);">Caricamento orari custode...</p>
                     </div>
                 </div>
             </main>
@@ -3452,6 +3738,50 @@
 
                 tableHTML += '</tbody></table>';
                 custodeContainer.innerHTML = tableHTML;
+            });
+
+            // Carica anche gli orari del custode
+            loadCustodeSchedule();
+        };
+
+        const loadCustodeSchedule = () => {
+            const scheduleContainer = document.getElementById('custode-schedule-container');
+            if (!scheduleContainer) return;
+
+            // Query per trovare i dati degli orari del custode
+            const qSchedule = query(collection(db, "importedCustodeSchedule"), orderBy("uploadedAt", "desc"), limit(1));
+            onSnapshot(qSchedule, (snapshot) => {
+                if (snapshot.empty) {
+                    scheduleContainer.innerHTML = `<p style="color:var(--secondary-text);">Nessun orario custode ancora importato.</p>`;
+                    return;
+                }
+
+                const scheduleData = snapshot.docs[0].data();
+                if (scheduleData.tableData && scheduleData.tableData.length > 0) {
+                    const headers = Object.keys(scheduleData.tableData[0]);
+                    let tableHTML = `<table class="data-table">
+                        <thead>
+                            <tr>`;
+                    
+                    headers.forEach(header => {
+                        tableHTML += `<th>${header.toUpperCase()}</th>`;
+                    });
+                    
+                    tableHTML += `</tr></thead><tbody>`;
+
+                    scheduleData.tableData.forEach(row => {
+                        tableHTML += `<tr>`;
+                        headers.forEach(header => {
+                            tableHTML += `<td>${row[header] || '–'}</td>`;
+                        });
+                        tableHTML += `</tr>`;
+                    });
+
+                    tableHTML += '</tbody></table>';
+                    scheduleContainer.innerHTML = tableHTML;
+                } else {
+                    scheduleContainer.innerHTML = `<p style="color:var(--secondary-text);">Nessun orario custode ancora importato.</p>`;
+                }
             });
         };
 


### PR DESCRIPTION
Add "Orari Custode" functionality, allowing supervisors to import Excel schedules and display them in the "Custode" section for all users.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a5a9435-601e-4310-90fd-77f068a02b14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6a5a9435-601e-4310-90fd-77f068a02b14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

